### PR TITLE
Allow keylime_server_t getattr of filesystem_type

### DIFF
--- a/keylime.te
+++ b/keylime.te
@@ -76,6 +76,7 @@ allow keylime_server_t self:udp_socket create_stream_socket_perms;
 manage_dirs_pattern(keylime_server_t, keylime_log_t, keylime_log_t)
 manage_files_pattern(keylime_server_t, keylime_log_t, keylime_log_t)
 
+fs_getattr_all_fs(keylime_server_t)
 fs_rw_inherited_tmpfs_files(keylime_server_t)
 
 optional_policy(`


### PR DESCRIPTION
Allow the keylime_server_t domain to
get the attributes of all filesystems.