### PR TITLE
Allow keylime_agent_t connect,read systemd_homed_t

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ jobs:
   targets:
     - fedora-stable
     - fedora-rawhide
-    - centos-stream-9-x86_64
+    - centos-stream-10-x86_64
   skip_build: true
   tf_extra_params:
     environments:
@@ -17,7 +17,7 @@ jobs:
   branch: rhel-9-main
   targets:
     centos-stream-9-x86_64:
-        distros: [RHEL-9.3.0-Nightly]
+        distros: [RHEL-9.4.0-Nightly]
   use_internal_tf: True
   skip_build: true
   tf_extra_params:

--- a/keylime.te
+++ b/keylime.te
@@ -129,6 +129,7 @@ kernel_stream_connect(keylime_agent_t)
 userdom_dontaudit_search_user_home_dirs(keylime_agent_t)
 
 auth_read_passwd(keylime_agent_t)
+auth_use_nsswitch(keylime_agent_t)
 
 keylime_mounton_var_lib(keylime_agent_t)
 

--- a/packit-ci.fmf
+++ b/packit-ci.fmf
@@ -48,6 +48,7 @@ adjust:
     url: https://github.com/RedHat-SP-Security/keylime-tests
     ref: main
     test:
+     - /setup/apply_workarounds
      - /setup/configure_tpm_emulator
      - /setup/install_upstream_keylime
      - /setup/install_rust_keylime_from_copr


### PR DESCRIPTION
Allow the specified domain to look up user, password, group, or host information using the name service.