### PR TITLE
Do not audit attempts to search cgroup directories by keylime_server_t

### DIFF
--- a/keylime.te
+++ b/keylime.te
@@ -83,6 +83,8 @@ allow keylime_server_t self:udp_socket create_stream_socket_perms;
 manage_dirs_pattern(keylime_server_t, keylime_log_t, keylime_log_t)
 manage_files_pattern(keylime_server_t, keylime_log_t, keylime_log_t)
 
+fs_dontaudit_search_cgroup_dirs(keylime_server_t)
+
 corenet_tcp_connect_http_cache_port(keylime_server_t)
 corenet_tcp_connect_mysqld_port(keylime_server_t)
 corenet_tcp_connect_postgresql_port(keylime_server_t)


### PR DESCRIPTION
keylime_server_t searches through control groups directories; allow rule does not need to be applied,so let's not audit the denials.