### PR TITLE
Add SELinux policy for keylime shared memory support

### DIFF
--- a/keylime.te
+++ b/keylime.te
@@ -77,6 +77,8 @@ optional_policy(`
 allow keylime_server_t self:key { create read setattr view write };
 allow keylime_server_t self:netlink_route_socket { create_stream_socket_perms nlmsg_read };
 allow keylime_server_t self:udp_socket create_stream_socket_perms;
+allow keylime_server_t keylime_tmp_t:sock_file { create write };
+allow keylime_server_t self:unix_stream_socket connectto;
 
 fs_dontaudit_search_cgroup_dirs(keylime_server_t)
 


### PR DESCRIPTION
Allow keylime_server_t to create Unix socket files and connect to self, required by the new shared memory functionality in keylime.

## Summary by Sourcery

Allow the keylime SELinux policy to support shared-memory-based communication by permitting the keylime server domain to create Unix socket files and connect to itself for the new shared memory functionality.

Enhancements:
- Extend the keylime_server_t SELinux policy to allow creation of Unix domain socket files.
- Permit keylime_server_t to establish self-connections required for shared memory support.