### PR TITLE
Add SELinux support for socket operations in /run/keylime/

### DIFF
--- a/keylime.fc
+++ b/keylime.fc
@@ -20,3 +20,5 @@
 
 /var/lib/keylime(/.*)?		gen_context(system_u:object_r:keylime_var_lib_t,s0)
 /var/lib/keylime-agent(/.*)?		gen_context(system_u:object_r:keylime_var_lib_t,s0)
+
+/run/keylime(/.*)?		gen_context(system_u:object_r:keylime_var_run_t,s0)

--- a/keylime.te
+++ b/keylime.te
@@ -23,6 +23,9 @@ files_type(keylime_var_lib_t)
 type keylime_tmp_t;
 files_tmp_file(keylime_tmp_t)
 
+type keylime_var_run_t;
+files_pid_file(keylime_var_run_t)
+
 ########################################
 #
 # keylime domain policy
@@ -79,6 +82,11 @@ allow keylime_server_t self:netlink_route_socket { create_stream_socket_perms nl
 allow keylime_server_t self:udp_socket create_stream_socket_perms;
 allow keylime_server_t keylime_tmp_t:sock_file { create write };
 allow keylime_server_t self:unix_stream_socket connectto;
+
+# Allow keylime_server_t to manage runtime directory and sockets in /run/keylime/
+manage_dirs_pattern(keylime_server_t, keylime_var_run_t, keylime_var_run_t)
+manage_sock_files_pattern(keylime_server_t, keylime_var_run_t, keylime_var_run_t)
+files_pid_filetrans(keylime_server_t, keylime_var_run_t, { dir sock_file })
 
 fs_dontaudit_search_cgroup_dirs(keylime_server_t)
 fs_read_cgroup_files(keylime_server_t)


### PR DESCRIPTION
## Summary

This PR adds SELinux policy support for keylime socket operations in `/run/keylime/`.

**Resolves:** #32

## Changes

### Add `keylime_var_run_t` type for `/run/keylime/`

**Type declaration:**
```selinux
type keylime_var_run_t;
files_pid_file(keylime_var_run_t)
```

The `files_pid_file()` macro automatically assigns the appropriate SELinux attributes (`file_type` and `pidfile`) for runtime directories, ensuring proper integration with existing policy expectations for `/run` content.

**File context added:**
```selinux
/run/keylime(/.*)?    gen_context(system_u:object_r:keylime_var_run_t,s0)
```

**Policy rules added:**
```selinux
manage_dirs_pattern(keylime_server_t, keylime_var_run_t, keylime_var_run_t)
manage_sock_files_pattern(keylime_server_t, keylime_var_run_t, keylime_var_run_t)
files_pid_filetrans(keylime_server_t, keylime_var_run_t, { dir sock_file })
```

This allows keylime services to create and manage IPC sockets in `/run/keylime/`, including:
- ZeroMQ IPC socket (`keylime.verifier.ipc`)
- SharedDataManager socket (`shared_data.<pid>.sock`)

## Problem Statement

The keylime verifier and registrar services create Unix domain sockets for IPC, but there was no SELinux file context defined for `/run/keylime/`. This caused the directory to get the generic `var_run_t` label, and `keylime_server_t` had no permissions to create sockets there.

**Before this PR:**
```bash
# ls -ldZ /run/keylime/
drwx------. 2 keylime keylime system_u:object_r:var_run_t:s0 /run/keylime/
```

**After this PR:**
```bash
# ls -ldZ /run/keylime/
drwx------. 2 keylime keylime system_u:object_r:keylime_var_run_t:s0 /run/keylime/
```

## Design Rationale

### Why not add `unlink` permission to `keylime_tmp_t:sock_file`?

Instead of broadening permissions on temporary files in `/tmp` (which would grant `unlink` to all `keylime_tmp_t` sock_files), this PR implements the proper solution: dedicated runtime directory management in `/run/keylime/` with the specific `keylime_var_run_t` type.

This approach:
- ✅ Follows SELinux principle of least privilege
- ✅ Uses standard location for daemon runtime files (`/run`)
- ✅ Avoids overly broad permissions on `/tmp` content
- ✅ Integrates properly with systemd tmpfiles.d

### Coordination with keylime code changes

This policy update should be deployed alongside keylime code changes that move socket creation from `/tmp` to `/run/keylime/`. The keylime application changes include:
- Moving SyncManager sockets to `/run/keylime/shared_data.<pid>.sock`
- Adding tmpfiles.d configuration for `/run/keylime/` directory creation
- Ensuring proper directory permissions (0700, keylime:keylime ownership)

## Testing

### Environment
- Fedora 43 (Linux 6.19.11)
- keylime with socket relocation patches (PR TBD)
- SELinux enforcing mode

### Verification Steps

1. **Install updated policy:**
   ```bash
   sudo semodule -i keylime.pp
   sudo restorecon -Rv /run/keylime/
   ```

2. **Verify file context:**
   ```bash
   # ls -lZ /run/keylime/
   drwx------. 2 keylime keylime system_u:object_r:keylime_var_run_t:s0 /run/keylime/
   ```

3. **Test service startup and shutdown:**
   ```bash
   sudo systemctl restart keylime_verifier
   sudo systemctl stop keylime_verifier
   ```

4. **Verify socket creation:**
   ```bash
   # ls -lZ /run/keylime/*.sock
   srwx------. 1 keylime keylime system_u:object_r:keylime_var_run_t:s0 shared_data.12345.sock
   ```

5. **Check for AVC denials:**
   ```bash
   sudo ausearch -m avc -ts recent | grep keylime
   # Should show no denials related to socket operations in /run/keylime/
   ```

### Results
- ✅ No AVC denials during service start/stop
- ✅ `/run/keylime/` gets correct `keylime_var_run_t` context
- ✅ Sockets created and removed without permission errors
- ✅ Policy compiles successfully
- ✅ Proper SELinux attributes assigned via `files_pid_file()` macro

## Files Modified

- `keylime.te`: Add type declaration and policy rules
- `keylime.fc`: Add file context for `/run/keylime(/.*)?`

---

*This PR was created with assistance from Claude Code (claude.ai/code). All changes have been reviewed and verified by the author.*