### PR TITLE
Allow keylime_server_t to read /proc/net network state

### DIFF
--- a/keylime.te
+++ b/keylime.te
@@ -92,6 +92,7 @@ fs_dontaudit_search_cgroup_dirs(keylime_server_t)
 fs_read_cgroup_files(keylime_server_t)
 
 kernel_read_net_sysctls(keylime_server_t)
+kernel_read_network_state(keylime_server_t)
 
 corenet_tcp_connect_http_cache_port(keylime_server_t)
 corenet_tcp_connect_mysqld_port(keylime_server_t)


### PR DESCRIPTION
PR keylime/keylime#1852 ("ca: Add Subject Alternative Names to the certificates") introduced socket.gethostname() and socket.getfqdn() calls in ca_impl_openssl.get_san_entries() to populate certificate SANs with the system hostname and FQDN. socket.getfqdn() internally invokes socket.getaddrinfo(), which reads the /proc/net symlink (proc_net_t) for network configuration, causing AVC denials:

  type=AVC msg=audit(...): avc: denied { read } for
  comm="keylime_verifie" name="net" dev="proc"
  scontext=system_u:system_r:keylime_server_t:s0
  tcontext=system_u:object_r:proc_net_t:s0
  tclass=lnk_file permissive=0

Add kernel_read_network_state() which grants read access to both files and symlinks under /proc/net. This complements the existing kernel_read_net_sysctls() which only covers /proc/sys/net/.

## Summary by Sourcery

Bug Fixes:
- Grant keylime_server_t read access to /proc/net network state to prevent AVC denials triggered by certificate SAN hostname/FQDN resolution.