### PR TITLE
Add to keylime_agent_t to syslog_client_type attribute

### DIFF
--- a/keylime.te
+++ b/keylime.te
@@ -136,6 +136,8 @@ fs_setattr_tmpfs_dirs(keylime_agent_t)
 
 init_dontaudit_stream_connect(keylime_agent_t)
 
+logging_send_syslog_msg(keylime_agent_t)
+
 kernel_read_all_proc(keylime_agent_t)
 kernel_stream_connect(keylime_agent_t)
 


### PR DESCRIPTION
Allow the specified domain to connect to the
system log service (syslog), to send messages be added to the system logs.

## Summary by Sourcery

New Features:
- Grant the keylime agent SELinux domain permission to act as a syslog client so it can write to system logs.